### PR TITLE
Add KubeStellar Console to multi-cloud management tools

### DIFF
--- a/docs/en/tools/multi-cloud-management.md
+++ b/docs/en/tools/multi-cloud-management.md
@@ -10,6 +10,7 @@
 | **Crossplane** | Open-source Kubernetes-based control plane for managing infrastructure from multiple providers using declarative APIs. | [Crossplane](https://www.crossplane.io) |
 | **Scalr** | Infrastructure as Code management platform focused on governance, policy enforcement, and cost controls. | [Scalr](https://scalr.com) |
 | **env0** | GitOps-oriented Infrastructure as Code automation platform supporting Terraform, Terragrunt, and related workflows. | [env0](https://www.env0.com) |
+| **KubeStellar Console** | Multi-cluster Kubernetes dashboard with real-time observability, AI-powered operations, and unified management across edge and cloud clusters. | [KubeStellar Console](https://github.com/kubestellar/console) |
 
 ## Why Multi-cloud?
 


### PR DESCRIPTION
Add [KubeStellar Console](https://github.com/kubestellar/console) to the multi-cloud management tools section.

KubeStellar Console is a multi-cluster Kubernetes dashboard that provides real-time observability, AI-powered operations, and unified management across edge and cloud clusters. It is a CNCF project and integrates with 20+ CNCF projects.

- Follows existing table format
- Resource is actively maintained
- Link verified